### PR TITLE
Update loader.js

### DIFF
--- a/py2cytoscape/cytoscapejs/loader.js
+++ b/py2cytoscape/cytoscapejs/loader.js
@@ -1,6 +1,9 @@
 if (window['cytoscape'] === undefined) {
     var paths = {
-        cytoscape: 'http://cytoscape.github.io/cytoscape.js/api/cytoscape.js-latest/cytoscape.min'
+        //seems like cystoscape.min.js has been relocated
+        //from version 3.0.0 cytoscape.min.js does not work :(
+        //cytoscape: 'http://cytoscape.github.io/cytoscape.js/api/cytoscape.js-latest/cytoscape.min'
+        cytoscape: 'https://cdnjs.cloudflare.com/ajax/libs/cytoscape/2.7.21/cytoscape.min'
     };
 
     require.config({


### PR DESCRIPTION
It seems like cystoscape.min.js has been relocated and is no longer accessible at: http://cytoscape.github.io/cytoscape.js/api/cytoscape.js-latest/cytoscape.min, however even from a valid address (e.g. https://raw.githubusercontent.com/cytoscape/cytoscape.js/master/dist/cytoscape.min.js) it appears to be uncompatible (the reason is beyond my understanding) from version 3.0.0 cytoscape.min.js does not work.
Using a legacy version available at cloudflare worked for me.