### PR TITLE
Making util_dataframe.py python2 compatible. 

### DIFF
--- a/py2cytoscape/util/util_dataframe.py
+++ b/py2cytoscape/util/util_dataframe.py
@@ -85,12 +85,12 @@ def to_dataframe(network,
             if extra_column in edge_data:
                 extra_values.append(edge_data[extra_column])
                 valid_extra_cols.add(extra_column)
-        row = (source, itr, target, *extra_values)
+        row = tuple([source, itr, target] + extra_values)
         network_array.append(row)
 
     return pd.DataFrame(
         network_array,
-        columns=['source', 'interaction', 'target', *sorted(valid_extra_cols)]
+        columns=['source', 'interaction', 'target'] + sorted(valid_extra_cols)
     )
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -349,9 +349,8 @@ class NetworkDataframeTests(unittest.TestCase):
         from py2cytoscape.util.util_dataframe import to_dataframe
         with open(self.cur_dir + '/data/galFiltered.json', 'r') as f:
             network = json.load(f)
-        print(network)
-        to_dataframe(network, edges_attr_cols=['SUID'])
-
+        df = to_dataframe(network, edges_attr_cols=['SUID'])
+        self.assertIn('SUID', df.columns)
 
 
 if __name__ == '__main__':

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -339,5 +339,20 @@ class NetworkConversionTests(unittest.TestCase):
         self.assertEqual(target_edge['ebw'], edge0['data']['ebw'])
 
 
+class NetworkDataframeTests(unittest.TestCase):
+
+    def setUp(self):
+        self.cur_dir = os.path.dirname(os.path.realpath(__file__))
+        pass
+
+    def test_to_dateframe(self):
+        from py2cytoscape.util.util_dataframe import to_dataframe
+        with open(self.cur_dir + '/data/galFiltered.json', 'r') as f:
+            network = json.load(f)
+        print(network)
+        to_dataframe(network, edges_attr_cols=['SUID'])
+
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Currently there are two lines that unpack lists with a list or tuple, which was introduced in python 3.5 (https://www.python.org/dev/peps/pep-3132/).

Found this error when the project MAGINE started failing (https://travis-ci.org/LoLab-VU/MAGINE/jobs/386242770). 

Then saw that it is failing during installation portion of py2cytoscape (line 754 for python2 build)
https://travis-ci.org/cytoscape/py2cytoscape/jobs/385068789. That portion doesn't get called in the unittests, so I guess it doesn't get caught. 