### PR TITLE
Update util_networkx.py

### DIFF
--- a/py2cytoscape/util/util_networkx.py
+++ b/py2cytoscape/util/util_networkx.py
@@ -107,7 +107,7 @@ def from_networkx(g, layout=None, scale=DEF_SCALE):
     cygraph[DATA] = __map_table_data(g.graph.keys(), g.graph)
 
     for i, node_id in enumerate(nodes):
-        new_node = __create_node(g.node[node_id], node_id)
+        new_node = __create_node(g.nodes[node_id], node_id)
         if layout is not None:
             new_node['position'] = pos[i]
 


### PR DESCRIPTION
Networkx 2.4+ changed "G.node" to "G.nodes"
https://networkx.github.io/documentation/stable/release/release_2.4.html#deprecations